### PR TITLE
Enhance link previews with actual page title

### DIFF
--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -58,6 +58,9 @@ module.exports = (src, previewSrc, previewDest, sink = () => map()) => (done) =>
                 }, {})
               uiModel.page.layout = doc.getAttribute('page-layout', 'default')
               uiModel.page.title = doc.getDocumentTitle()
+              uiModel.page.description = doc.getAttribute('description')
+              uiModel.page.keywords = doc.getAttribute('keywords')
+              uiModel.page.author = doc.getAuthor()
               uiModel.page.contents = Buffer.from(doc.convert())
             }
             file.extname = '.html'

--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -1,19 +1,14 @@
 'use strict'
 
-// NOTE remove patch after upgrading from asciidoctor.js to @asciidoctor/core
-Error.call = (self, ...args) => {
-  const err = new Error(...args)
-  return Object.assign(self, { message: err.message, stack: err.stack })
-}
-
-const asciidoctor = require('asciidoctor.js')()
+const Asciidoctor = require('@asciidoctor/core')()
 const fs = require('fs-extra')
 const handlebars = require('handlebars')
-const { obj: map } = require('through2')
 const merge = require('merge-stream')
 const ospath = require('path')
 const path = ospath.posix
 const requireFromString = require('require-from-string')
+const { Transform } = require('stream')
+const map = (transform = () => {}, flush = undefined) => new Transform({ objectMode: true, transform, flush })
 const vfs = require('vinyl-fs')
 const yaml = require('js-yaml')
 
@@ -26,7 +21,21 @@ module.exports = (src, previewSrc, previewDest, sink = () => map()) => (done) =>
       merge(compileLayouts(src), registerPartials(src), registerHelpers(src), copyImages(previewSrc, previewDest))
     ),
   ])
-    .then(([baseUiModel, { layouts }]) => [{ ...baseUiModel, env: process.env }, layouts])
+    .then(([baseUiModel, { layouts }]) => {
+      const extensions = ((baseUiModel.asciidoc || {}).extensions || []).map((request) => {
+        ASCIIDOC_ATTRIBUTES[request.replace(/^@|\.js$/, '').replace(/[/]/g, '-') + '-loaded'] = ''
+        const extension = require(request)
+        extension.register.call(Asciidoctor.Extensions)
+        return extension
+      })
+      const asciidoc = { extensions }
+      for (const component of baseUiModel.site.components) {
+        for (const version of component.versions || []) version.asciidoc = asciidoc
+      }
+      baseUiModel = { ...baseUiModel, env: process.env }
+      delete baseUiModel.asciidoc
+      return [baseUiModel, layouts]
+    })
     .then(([baseUiModel, layouts]) =>
       vfs
         .src('**/*.adoc', { base: previewSrc, cwd: previewSrc })
@@ -36,16 +45,15 @@ module.exports = (src, previewSrc, previewDest, sink = () => map()) => (done) =>
             const uiModel = { ...baseUiModel }
             uiModel.page = { ...uiModel.page }
             uiModel.siteRootPath = siteRootPath
-            uiModel.siteRootUrl = path.join(siteRootPath, 'index.html')
             uiModel.uiRootPath = path.join(siteRootPath, '_')
             if (file.stem === '404') {
               uiModel.page = { layout: '404', title: 'Page Not Found' }
             } else {
-              const doc = asciidoctor.load(file.contents, { safe: 'safe', attributes: ASCIIDOC_ATTRIBUTES })
+              const doc = Asciidoctor.load(file.contents, { safe: 'safe', attributes: ASCIIDOC_ATTRIBUTES })
               uiModel.page.attributes = Object.entries(doc.getAttributes())
                 .filter(([name, val]) => name.startsWith('page-'))
                 .reduce((accum, [name, val]) => {
-                  accum[name.substr(5)] = val
+                  accum[name.slice(5)] = val
                   return accum
                 }, {})
               uiModel.page.layout = doc.getAttribute('page-layout', 'default')
@@ -62,7 +70,7 @@ module.exports = (src, previewSrc, previewDest, sink = () => map()) => (done) =>
           })
         )
         .pipe(vfs.dest(previewDest))
-        .on('error', (e) => done)
+        .on('error', done)
         .pipe(sink())
     )
 
@@ -126,7 +134,7 @@ function transformHandlebarsError ({ message, stack }, layout) {
   const m = stack.match(/^ *at Object\.ret \[as (.+?)\]/m)
   const templatePath = `src/${m ? 'partials/' + m[1] : 'layouts/' + layout}.hbs`
   const err = new Error(`${message}${~message.indexOf('\n') ? '\n^ ' : ' '}in UI template ${templatePath}`)
-  err.stack = [err.toString()].concat(stack.substr(message.length + 8)).join('\n')
+  err.stack = [err.toString()].concat(stack.slice(message.length + 8)).join('\n')
   return err
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "clipboard": "^2.0.6"
       },
       "devDependencies": {
-        "asciidoctor.js": "1.5.9",
+        "@asciidoctor/core": "^3.0.4",
         "autoprefixer": "~9.7",
         "browser-pack-flat": "~3.4",
         "browserify": "~16.5",
@@ -54,6 +54,79 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@asciidoctor/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asciidoctor/opal-runtime": "3.0.1",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz",
+      "integrity": "sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "8.1.0",
+        "unxhr": "1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@asciidoctor/opal-runtime/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -923,20 +996,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/asciidoctor.js": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/asciidoctor.js/-/asciidoctor.js-1.5.9.tgz",
-      "integrity": "sha512-k5JgwyV82TsiCpnYbDPReuHhzf/vRUt6NaZ+OGywkDDGeGG/CPfvN2Gd1MJ0iIZKDyuk4iJHOdY/2x1KBrWMzA==",
-      "dev": true,
-      "dependencies": {
-        "opal-runtime": "1.0.11"
-      },
-      "engines": {
-        "node": ">=8.11",
-        "npm": ">=5.0.0",
-        "yarn": ">=1.1.0"
       }
     },
     "node_modules/asn1.js": {
@@ -5342,22 +5401,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -8882,19 +8925,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/opal-runtime": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/opal-runtime/-/opal-runtime-1.0.11.tgz",
-      "integrity": "sha512-L+6pnRvXPlDtbamBRnJAnB9mEMXmsIQ/b+0r/2xJ5/n/nxheEkLo+Pm5QNQ08LEbEN9TI6/kedhIspqRRu6tXA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "6.0.4",
-        "xmlhttprequest": "1.8.0"
-      },
-      "engines": {
-        "node": ">=8.11"
       }
     },
     "node_modules/optionator": {
@@ -13899,6 +13929,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/unxhr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.11"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -14460,15 +14500,6 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -14693,6 +14724,59 @@
     }
   },
   "dependencies": {
+    "@asciidoctor/core": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-3.0.4.tgz",
+      "integrity": "sha512-41SDMi7iRRBViPe0L6VWFTe55bv6HEOJeRqMj5+E5wB1YPdUPuTucL4UAESPZM6OWmn4t/5qM5LusXomFUVwVQ==",
+      "dev": true,
+      "requires": {
+        "@asciidoctor/opal-runtime": "3.0.1",
+        "unxhr": "1.2.0"
+      }
+    },
+    "@asciidoctor/opal-runtime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz",
+      "integrity": "sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==",
+      "dev": true,
+      "requires": {
+        "glob": "8.1.0",
+        "unxhr": "1.2.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+          "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+          "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -15434,15 +15518,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
-    },
-    "asciidoctor.js": {
-      "version": "1.5.9",
-      "resolved": "https://registry.npmjs.org/asciidoctor.js/-/asciidoctor.js-1.5.9.tgz",
-      "integrity": "sha512-k5JgwyV82TsiCpnYbDPReuHhzf/vRUt6NaZ+OGywkDDGeGG/CPfvN2Gd1MJ0iIZKDyuk4iJHOdY/2x1KBrWMzA==",
-      "dev": true,
-      "requires": {
-        "opal-runtime": "1.0.11"
-      }
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -19251,19 +19326,6 @@
         }
       }
     },
-    "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-      "dev": true,
-      "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "glob-parent": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
@@ -22174,16 +22236,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "opal-runtime": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/opal-runtime/-/opal-runtime-1.0.11.tgz",
-      "integrity": "sha512-L+6pnRvXPlDtbamBRnJAnB9mEMXmsIQ/b+0r/2xJ5/n/nxheEkLo+Pm5QNQ08LEbEN9TI6/kedhIspqRRu6tXA==",
-      "dev": true,
-      "requires": {
-        "glob": "6.0.4",
-        "xmlhttprequest": "1.8.0"
       }
     },
     "optionator": {
@@ -26389,6 +26441,12 @@
         }
       }
     },
+    "unxhr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.2.0.tgz",
+      "integrity": "sha512-6cGpm8NFXPD9QbSNx0cD2giy7teZ6xOkCUH3U89WKVkL9N9rBrWjlCwhR94Re18ZlAop4MOc3WU1M3Hv/bgpIw==",
+      "dev": true
+    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -26878,12 +26936,6 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
-    },
-    "xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "last 2 versions"
   ],
   "devDependencies": {
-    "asciidoctor.js": "1.5.9",
+    "@asciidoctor/core": "^3.0.4",
     "autoprefixer": "~9.7",
     "browser-pack-flat": "~3.4",
     "browserify": "~16.5",

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -2,7 +2,9 @@
 :page-beta: true
 :beta: true
 = Commenting
-Author Name
+Author Name <author.name@magnolia-cms.com>
+:description: This module brings commenting features to your pages, including moderation and reactions.
+:keywords: commenting, CMS, moderation, reactions
 :idprefix:
 :idseparator: -
 :!example-caption:
@@ -10,6 +12,9 @@ Author Name
 :page-pagination:
 :page-layout: default
 :page-beta: true
+
+{description}
+The module also comes with a REST API for commenting and a Content App to view comments of an item.
 
 // ++++
 // <style>

--- a/src/partials/head-info.hbs
+++ b/src/partials/head-info.hbs
@@ -10,11 +10,14 @@
     {{/with}}
     {{/unless}}
     {{#with page.description}}
-    <meta name="description" content="{{this}}">
+    <meta name="description" content="{{{detag this}}}">
     {{/with}}
     {{#with page.keywords}}
-    <meta name="keywords" content="{{this}}">
+    <meta name="keywords" content="{{{this}}}">
+    {{/with}}
+    {{#with page.author}}
+    <meta name="author" content="{{{this}}}">
     {{/with}}
     {{#with (or antoraVersion site.antoraVersion)}}
-    <meta name="generator" content="Antora {{this}}">
+    <meta name="generator" content="Antora {{{this}}}">
     {{/with}}

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,5 +1,5 @@
     {{!-- Add additional meta tags here --}}
-<meta name="description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
-<meta property="og:title" content="Magnolia CMS Documentation">
-<meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
-<meta property="og:image" content="https://docs.magnolia-cms.com/welcome/_images/meta-og-2024.png">
+    <meta name="description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
+    <meta property="og:title" content="Magnolia CMS Documentation">
+    <meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
+    <meta property="og:image" content="https://docs.magnolia-cms.com/welcome/_images/meta-og-2024.png">

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -2,4 +2,4 @@
     <meta name="description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
     <meta property="og:title" content="Magnolia CMS Documentation">
     <meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
-    <meta property="og:image" content="https://docs.magnolia-cms.com/welcome/_images/meta-og-2024.png">
+    <meta property="og:image" content="{{site.url}}/home/_images/meta-og-2024.png">

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,5 +1,4 @@
     {{!-- Add additional meta tags here --}}
-    <meta name="description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
     <meta property="og:title" content="Magnolia CMS Documentation">
     <meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
     <meta property="og:image" content="{{site.url}}/home/_images/meta-og-2024.png">

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,5 +1,4 @@
     {{!-- Add additional meta tags here --}}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <meta name="description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
 <meta property="og:title" content="Magnolia CMS Documentation">
 <meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -1,4 +1,5 @@
     {{!-- Add additional meta tags here --}}
-    <meta property="og:title" content="Magnolia CMS Documentation">
-    <meta property="og:description" content="Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.">
+    <meta property="og:title" content="{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} | {{this}}{{/with}}">
+    <meta property="og:description" content="{{{detag (or page.description "Explore Magnolia CMS documentation for comprehensive guides and resources on implementing, integrating, and using Magnolia effectively.")}}}">
+    <meta property="og:url" content="{{site.url}}{{page.url}}">
     <meta property="og:image" content="{{site.url}}/home/_images/meta-og-2024.png">

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,4 +1,4 @@
 {{!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" /> --}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
-<link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+    <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,3 +1,4 @@
 {{!-- <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" /> --}}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
 <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/src/partials/head-title.hbs
+++ b/src/partials/head-title.hbs
@@ -1,1 +1,1 @@
-    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} :: {{this}}{{/with}}</title>
+    <title>{{{detag (or page.title defaultPageTitle)}}}{{#with site.title}} | {{this}}{{/with}}</title>


### PR DESCRIPTION
_e.g._ when pasting links into Confluence, Slack, etc. (previously they would all show "Magnolia CMS docs")

this PR also aims to support standard Asciidoc `:description:` and `:keywords:` attributes if set on pages.