### PR TITLE
Add EU AI Act statement link to docs site footer

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -49,6 +49,7 @@
     <p style="margin-top: 1.25vh;">
         <a href="https://www.magnolia-cms.com/legal/privacy.html" target="_blank" rel="noreferrer, noopener" style="font-size: smaller; margin-right: 1vw;" aria-label="Read Magnolia's official Privacy Policy">Privacy policy</a>
         <a href="https://www.magnolia-cms.com/legal/accessiblity-statement.html" target="_blank" rel="noreferrer, noopener" style="font-size: smaller; margin-right: 1vw;" aria-label="Read Magnolia's official Accessibility Statement">Accessibility statement</a>
+        <a href="https://www.magnolia-cms.com/legal/eu-ai-act-statement.html" target="_blank" rel="noreferrer, noopener" style="font-size: smaller; margin-right: 1vw;" aria-label="Read Magnolia's EU AI Act statement">EU AI Act statement</a>
         <a href="{{{siteRootPath}}}/ai-governance/ai-assisted-content/" target="_blank" rel="noreferrer, noopener" style="font-size: smaller;"  aria-label="Read about AI-assisted content in Magnolia documentation"> AI use in documentation </a>
     </p>
 </div>


### PR DESCRIPTION
Adds a link to Magnolia's published EU AI Act statement (https://www.magnolia-cms.com/legal/eu-ai-act-statement.html) alongside Privacy policy and Accessibility statement in the site footer, per Sorina's request in Slack (https://magnolia-cms.slack.com/archives/C0BFN5E1L06/p1784814917633709) to link it from any site promoting Magnolia's AI functionality.